### PR TITLE
Use ISO8601 as date format and fix issues with timestamp rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@
 A revised version of sig2dot (creating PGP signing web-of-trust-graphics) written in python.
 
 ## REQUIREMENTS
-sig2dot (revised) uses python3. If you do not have python3 installed,
+sig2dot (revised) uses python >= 3.3. If you do not have python3 installed,
 get it at: http://www.python.org/.
 
 If you're using Debian/Ubuntu or any other .deb-based Distribution, you can
 most likely just type:
 ```$ sudo aptitude install python3```
+
+You also need the iso8601 python module:
+```$ sudo pip3 install iso8601```
 
 The most important application is gnupg. Without it, you are unable to feed
 sig2dot with data.

--- a/sig2dot/exporter/dot/writer.py
+++ b/sig2dot/exporter/dot/writer.py
@@ -21,7 +21,6 @@
 import sys
 
 from colorsys import rgb_to_hsv
-from time import time, gmtime
 from calendar import timegm
 
 from gpg import OpenPGPKey, OpenPGPSig
@@ -42,9 +41,9 @@ def create_dot(keylist, title, trans, date):
     @type date:       string (YYYY-MM-DD)
     """
     
-    unixtime = get_renderdate(date)
+    unixtime = int(date.timestamp())
     
-    print("Renderdate: ", unixtime, file=sys.stderr)
+    print("Renderdate: %s (%d)" % (date.isoformat(), unixtime), file=sys.stderr)
 
     # Calculate maximums for colouring
     max_sigs = get_max_sigs(keylist)
@@ -61,20 +60,6 @@ def create_dot(keylist, title, trans, date):
 #==============================================================================
 # Helper functions for other functions
 #==============================================================================
-    
-def get_renderdate(date):
-    
-    y, m, d = gmtime().tm_year, gmtime().tm_mon, gmtime().tm_mday 
-    if date:
-        try:
-            y, m, d = date.split("-")
-        except:
-            pass
-    
-    renderdate = timegm((int(y), int(m), int(d), 0, 0, 0))
-    
-    return renderdate
-
 
 def get_relations(keylist, unixtime):
     

--- a/sig2dot/sig2dot.py
+++ b/sig2dot/sig2dot.py
@@ -36,11 +36,12 @@
 
 import sys
 
+import iso8601
 from gettext import gettext as _
 
 from gpg import OpenPGPKey, OpenPGPSig
 from gpg.colonimporter import PubLine, ParsedLine, LineParser, SigLine, UidLine
-from datetime import date
+from datetime import datetime
 
 import exporter.dot.writer as dot
 
@@ -206,10 +207,11 @@ LANG=C gpg --no-options --with-colons --fixed-list-mode  --list-sigs
     parser.add_option(  "-d", "--date",
                         dest="renderdate",
                         action="store",
-                        default=date.today().isoformat(),
+                        default=datetime.utcnow().isoformat(),
                         help="""Render graph as it appeared on <date> 
                         (ignores more recent signatures).  
-                        Date must be in the format "YYYY-MM-DD".  
+                        Date must be in the ISO8601 format.  
+                        UTC is assumed if zone designator is missing.  
                         Will also ignore keys that have since been revoked.""" )
 
     parser.add_option(  "-q", "--quiet",
@@ -250,9 +252,10 @@ def check_opts(opts):
         print("Version: 0.1.1")
         sys.exit(0)
 
-    split_date = opts.renderdate.split("-")
-    if len(split_date) != 3:
-        print("Please specify date in this format: \"YYYY-MM-DD\"", 
+    try:
+        opts.renderdate = iso8601.parse_date(opts.renderdate)
+    except iso8601.iso8601.ParseError:
+        print("Please specify date in ISO8601 format.", 
               file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
The datetime.timestamp() is new in Python 3.3. Dependency on iso8601 added

Fixes #2 