### PR TITLE
Add initial pytest tests for lineparser, pgpkey, pgpsig

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ $ gpg --no-options --with-colons --fixed-list-mode  --list-sigs \
 ```
 Then convert it using neato:
 ```$ neato -Tpng myLUG.dot > myLUG.png```
+
+## CONTRIBUTING
+Testing is done with pytest via tox:
+```$ pip install tox```
+```$ tox```

--- a/tests/test_lineparser.py
+++ b/tests/test_lineparser.py
@@ -1,0 +1,94 @@
+import os.path
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import sig2dot.gpg.colonimporter.LineParser
+import sig2dot.gpg.colonimporter.PubLine
+import sig2dot.gpg.colonimporter.SigLine
+import sig2dot.gpg.colonimporter.UidLine
+
+def test_parse_pub_line_with_expiry_date():
+    _id = "ABCDEF0123456789"
+    creation_date = "1514764800"
+    expiry_date = "1577836800"
+
+    line = f"pub:u:3072:1:{_id}:{creation_date}:{expiry_date}::u:::scESC::::::23::0:"
+
+    result = sig2dot.gpg.colonimporter.LineParser.parse_line(line)
+
+    assert isinstance(result, sig2dot.gpg.colonimporter.PubLine.PubLine)
+    assert result.id == _id
+    assert result.creationdate == creation_date
+    assert result.expireydate == expiry_date
+
+def test_parse_pub_line_without_expiry_date():
+    _id = "ABCDEF0123456789"
+    creation_date = "1514764800"
+
+    line = f"pub:u:3072:1:{_id}:{creation_date}:::u:::scESC::::::23::0:"
+
+    result = sig2dot.gpg.colonimporter.LineParser.parse_line(line)
+
+    assert isinstance(result, sig2dot.gpg.colonimporter.PubLine.PubLine)
+    assert result.id == _id
+    assert result.creationdate == creation_date
+    assert result.expireydate == -1
+
+def test_parse_sig_line_with_expiry():
+    _id = "ABCDEF0123456789"
+    sign_date = "1514764800"
+    expiry_date = "1577836800"
+    name = "Bob Example <bob@example.com>"
+
+    line = f"sig:::1:{_id}:{sign_date}:{expiry_date}:::{name}:13x:::::10:"
+
+    result = sig2dot.gpg.colonimporter.LineParser.parse_line(line)
+
+    assert isinstance(result, sig2dot.gpg.colonimporter.SigLine.SigLine)
+    assert result.id == _id
+    assert result.signdate == sign_date
+    assert result.expirydate == expiry_date
+    assert result.name == name
+
+def test_parse_sig_line_without_expiry():
+    _id = "ABCDEF0123456789"
+    sign_date = "1514764800"
+    name = "Bob Example <bob@example.com>"
+
+    line = f"sig:::1:{_id}:{sign_date}::::{name}:13x:::::10:"
+
+    result = sig2dot.gpg.colonimporter.LineParser.parse_line(line)
+
+    assert isinstance(result, sig2dot.gpg.colonimporter.SigLine.SigLine)
+    assert result.id == _id
+    assert result.signdate == sign_date
+    assert result.expirydate == -1
+    assert result.name == name
+
+def test_parse_uid_line_with_comment():
+    name = "Bob Example"
+    comment = "Example Inc"
+    email = "bob@example.com"
+
+    line = f"uid:u::::1514764800::ABCDEABCDEABCDEABCDE01234567890123456789::{name} ({comment}) <{email}>::::::::::0:"
+
+    result = sig2dot.gpg.colonimporter.LineParser.parse_line(line)
+
+    assert isinstance(result, sig2dot.gpg.colonimporter.UidLine.UidLine)
+    assert result.name == name
+    assert result.comment == comment
+    assert result.email == email
+
+def test_parse_uid_line_without_comment():
+    name = "Bob Example"
+    email = "bob@example.com"
+
+    line = f"uid:u::::1514764800::ABCDEABCDEABCDEABCDE01234567890123456789::{name} <{email}>::::::::::0:"
+
+    result = sig2dot.gpg.colonimporter.LineParser.parse_line(line)
+
+    assert isinstance(result, sig2dot.gpg.colonimporter.UidLine.UidLine)
+    assert result.name == name
+    assert result.comment == ""
+    assert result.email == email

--- a/tests/test_pgpkey.py
+++ b/tests/test_pgpkey.py
@@ -1,0 +1,41 @@
+import os.path
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import sig2dot.gpg.OpenPGPKey
+
+def test_blank_key():
+    result = sig2dot.gpg.OpenPGPKey.OpenPGPKey()
+
+    assert result.id == ""
+    assert result.creationdate == 0
+    assert result.expireydate == 0
+    assert result.name == ""
+    assert result.comment == ""
+    assert result.email == ""
+    assert not result.sigs
+    assert not result.signed
+
+def test_key_properties():
+    _id = "ABCDEF0123456789"
+    creation_date = "1514764800"
+    expiry_date = "1577836800"
+    name = "Bob Example"
+    comment = "Example Inc"
+    email = "bob@example.com"
+
+    result = sig2dot.gpg.OpenPGPKey.OpenPGPKey()
+    result.id = _id
+    result.creationdate = creation_date
+    result.expireydate = expiry_date
+    result.name = name
+    result.comment = comment
+    result.email = email
+
+    assert result.id == _id
+    assert result.creationdate == creation_date
+    assert result.expireydate == expiry_date
+    assert result.name == name
+    assert result.comment == comment
+    assert result.email == email

--- a/tests/test_pgpsig.py
+++ b/tests/test_pgpsig.py
@@ -1,0 +1,27 @@
+import os.path
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import sig2dot.gpg.OpenPGPSig
+
+def test_blank_sig():
+    result = sig2dot.gpg.OpenPGPSig.OpenPGPSig()
+
+    assert result.id == ""
+    assert result.signdate == -1
+    assert result.expirydate == -1
+
+def test_sig_properties():
+    _id = "ABCDEF0123456789"
+    sign_date = "1514764800"
+    expiry_date = "1577836800"
+
+    result = sig2dot.gpg.OpenPGPSig.OpenPGPSig()
+    result.id = _id
+    result.signdate = sign_date
+    result.expirydate = expiry_date
+
+    assert result.id == _id
+    assert result.signdate == sign_date
+    assert result.expirydate == expiry_date

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py36
+skipsdist = True
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest tests


### PR DESCRIPTION
This adds some initial unit tests and a structure for future tests. Related to #1 